### PR TITLE
Add per-uid global field files alongside globalfields.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Contentstack
+Copyright (c) 2026 Contentstack
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kickstart-stack-seed",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This repository provides the Kickstart stack content for Kickstart projects. An easy way to import this stack content is by using the CLI seed command.",
   "repository": {
     "type": "git",

--- a/stack/global_fields/block.json
+++ b/stack/global_fields/block.json
@@ -1,0 +1,98 @@
+{
+  "title": "Block",
+  "uid": "block",
+  "schema": [
+    {
+      "data_type": "text",
+      "display_name": "Title",
+      "uid": "title",
+      "field_metadata": {
+        "description": "",
+        "default_value": "Block title",
+        "version": 3
+      },
+      "format": "",
+      "error_messages": {
+        "format": ""
+      },
+      "mandatory": false,
+      "multiple": false,
+      "non_localizable": false,
+      "unique": false
+    },
+    {
+      "data_type": "text",
+      "display_name": "Copy",
+      "uid": "copy",
+      "field_metadata": {
+        "allow_rich_text": true,
+        "description": "",
+        "multiline": false,
+        "rich_text_type": "custom",
+        "options": [
+          "html",
+          "bold",
+          "underline",
+          "italic",
+          "deleted",
+          "link",
+          "h2",
+          "h3",
+          "h4",
+          "h5",
+          "h6"
+        ],
+        "version": 3
+      },
+      "mandatory": false,
+      "multiple": false,
+      "non_localizable": false,
+      "unique": false
+    },
+    {
+      "data_type": "file",
+      "display_name": "Image",
+      "uid": "image",
+      "extensions": [],
+      "field_metadata": {
+        "description": "",
+        "rich_text_type": "standard"
+      },
+      "mandatory": false,
+      "multiple": false,
+      "non_localizable": false,
+      "unique": false
+    },
+    {
+      "data_type": "text",
+      "display_name": "Layout",
+      "display_type": "dropdown",
+      "enum": {
+        "advanced": true,
+        "choices": [
+          {
+            "value": "image_left",
+            "key": "Image Left"
+          },
+          {
+            "value": "image_right",
+            "key": "Image Right"
+          }
+        ]
+      },
+      "multiple": false,
+      "uid": "layout",
+      "field_metadata": {
+        "description": "",
+        "default_value": "",
+        "default_key": "",
+        "instruction": "Image left or right in the layout",
+        "version": 3
+      },
+      "mandatory": false,
+      "non_localizable": false,
+      "unique": false
+    }
+  ],
+  "description": "A block!"
+}


### PR DESCRIPTION
Each global field in `globalfields.json` now has its own `{uid}.json` file in `stack/global_fields/`. The original `globalfields.json` is kept intact.

**Files added**
- `stack/global_fields/block.json`